### PR TITLE
Widen horizontal margins in Home page.

### DIFF
--- a/src/components/Home/index.scss
+++ b/src/components/Home/index.scss
@@ -31,6 +31,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+	margin: 0 3em 0 3em;
     p {
       font-family: Open Sans;
       font-style: normal;
@@ -109,6 +110,7 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+	margin: 0 3em 0 3em;
   }
   .card {
     display: flex;


### PR DESCRIPTION
Left and right margins in Home page were too narrow and almost hit
sides when the browser's the same width as max-width, widening them
a little bit to make the page more aesthetically pleasing.